### PR TITLE
Add run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Run the application:
 go run main.go
 ```
 
+You can also use the built-in CLI commands:
+
+```bash
+# Generate a configuration by analyzing API docs
+idrinkyourmilkshake integrate -d https://example.com/api/docs -o integration-config.json
+
+# Execute the integration using the generated configuration
+idrinkyourmilkshake run -c integration-config.json
+```
+
 By default, the application will process the Dyflexis API documentation at [dyflexis](https://developer.dyflexis.com/v3).
 
 To analyze a different API, modify the user prompt in `main.go`.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/theapemachine/idrinkyourmilkshake/engine"
+	"github.com/theapemachine/idrinkyourmilkshake/models"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run an integration using a configuration file",
+	Long:  `Execute the integration engine with the provided API configuration.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		configFile, err := cmd.Flags().GetString("config")
+		if err != nil {
+			log.Fatalf("Failed to read config flag: %v", err)
+		}
+		if configFile == "" {
+			configFile = "integration-config.json"
+		}
+
+		data, err := os.ReadFile(configFile)
+		if err != nil {
+			log.Fatalf("Failed to read config file %s: %v", configFile, err)
+		}
+
+		var cfg models.APIConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			log.Fatalf("Failed to parse config file: %v", err)
+		}
+
+		eng := engine.NewIntegration(cfg)
+		if err := eng.Execute(); err != nil {
+			log.Fatalf("Integration failed: %v", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+	runCmd.Flags().StringP("config", "c", "integration-config.json", "Path to the integration configuration file")
+}


### PR DESCRIPTION
## Summary
- allow running integration configs from the CLI
- document how to use the new command

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*
- `go build ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command to execute integrations using a configuration file, with support for specifying the config file path.
- **Documentation**
  - Updated the README with instructions and examples for using the new CLI commands to generate and run integration configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->